### PR TITLE
feat: add redis

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -55,14 +55,14 @@ INSTALLED_APPS = [
 
 REST_USE_JWT = True
 
-REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
-    ),
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
-    )
-}
+# REST_FRAMEWORK = {
+#     'DEFAULT_PERMISSION_CLASSES': (
+#         'rest_framework.permissions.IsAuthenticated',
+#     ),
+#     'DEFAULT_AUTHENTICATION_CLASSES': (
+#         'rest_framework_simplejwt.authentication.JWTAuthentication',
+#     )
+# }
 
 # 추가적인 JWT_AUTH 설정
 SIMPLE_JWT = {
@@ -95,6 +95,14 @@ SIMPLE_JWT = {
     'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
     'SLIDING_TOKEN_LIFETIME': timedelta(minutes=5),
     'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
+}
+
+# redis
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379',
+    }
 }
 
 MIDDLEWARE = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ gunicorn==20.1.0
 drf_yasg==1.21.4
 djangorestframework-simplejwt==5.0.0
 django-prometheus==2.2.0
+django-redis==5.2.0
+requests==2.28.1

--- a/swagger/serializer.py
+++ b/swagger/serializer.py
@@ -59,7 +59,7 @@ class SwaggerUserSigninSerializer(serializers.Serializer):
 
 
 # Header
-def get_token():
+def header_authorization():
     parameter_token = openapi.Parameter(
         "Authorization",
         openapi.IN_HEADER,

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView
-
 from users.views import Signup, Signin
 
 urlpatterns = [

--- a/users/views.py
+++ b/users/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import authenticate
+from django.core.cache import cache
 from django.db import transaction
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
@@ -32,8 +33,7 @@ class Signup(APIView):
                 },
                 status=status.HTTP_201_CREATED,
             )
-            # jwt 토큰 => 쿠키에 저장
-            res.set_cookie("refresh", refresh_token, httponly=True)
+            cache.set(access_token, refresh_token, 60 * 60 * 3)
             return res
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -63,8 +63,7 @@ class Signin(APIView):
                     },
                     status=status.HTTP_200_OK,
                 )
-                # jwt 토큰 => 쿠키에 저장
-                res.set_cookie("refresh", refresh_token, httponly=True)
+                cache.set(access_token, refresh_token, 60*60*3)
                 return res
             else:
                 return Response(status=status.HTTP_401_UNAUTHORIZED)

--- a/waiting/views.py
+++ b/waiting/views.py
@@ -1,17 +1,20 @@
+import requests
+from django.core.cache import cache
 from django.db import transaction
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.settings import api_settings
 
 from backend.models import Token
 from store.models import Store
 from store.notification import notify
 from swagger.serializer import SwaggerWaitingsPostSerializer
-from users.models import User
 from waiting.models import Waiting
 from waiting.serializer import WaitingSerializer
-from swagger.serializer import get_token
+from swagger.serializer import header_authorization
 
 
 # 대기 순서
@@ -24,23 +27,45 @@ def search_waiting_order(waiting_id, store_id):
 # 헤더에 있는 토큰으로 유저 객체 get
 def search_user(request):
     jwt_object = JWTAuthentication()
-    header = jwt_object.get_header(request) # 헤더
-    raw_token = jwt_object.get_raw_token(header) # 원시 토큰
-    validated_token = jwt_object.get_validated_token(raw_token) # 검증된 토큰
-    user = jwt_object.get_user(validated_token) # 유저 객체
+    header = jwt_object.get_header(request)  # 헤더
+    raw_token = jwt_object.get_raw_token(header)  # 원시 토큰
+    validated_token = get_validated_token(raw_token)  # 검증된 토큰
+    user = jwt_object.get_user(validated_token)  # 유저 객체
     return user
 
 
+def get_validated_token(raw_token):
+    for AuthToken in api_settings.AUTH_TOKEN_CLASSES:
+        try:
+            return AuthToken(raw_token)
+        except TokenError:
+            raw_token = str(raw_token)
+            raw_token = raw_token[1:]
+            raw_token = raw_token.replace("'", "")
+            refresh_token = cache.get(raw_token)
+            if refresh_token is not None:
+                refresh = {
+                    "refresh": refresh_token
+                }
+                url = 'http://127.0.0.1:8000/api/v1/auth/user/refresh/'
+                response = requests.request(method='post', url=url, data=refresh)
+                access_token = response.text
+                access_token = access_token[11:]
+                access_token = access_token[:-2]
+                cache.set(access_token, refresh_token, 60 * 60 * 3)
+                raise Exception(access_token)
+            else:
+                raise Exception("로그인 하세용")
+
+
 class Waitings(APIView):
-    @swagger_auto_schema(tags=['Waiting'], manual_parameters=[get_token()])
+    @swagger_auto_schema(tags=['Waiting'], manual_parameters=[header_authorization()])
     @transaction.atomic
     def get(self, request):
         user = search_user(request)
         # 전화 번호, 비밀 번호를 이용해서 웨이팅 중인 데이터 반환
         try:
-            user_id = user.user_id
-            user_data = User.objects.get(id=user_id)
-            phone_num = user_data.phone_num
+            phone_num = user.phone_num
             db_data = Waiting.objects.get(phone_num=phone_num,
                                           status="WA")
         except:
@@ -55,7 +80,8 @@ class Waitings(APIView):
         serializer = WaitingSerializer(db_data)
         return Response(serializer.data, status=200)
 
-    @swagger_auto_schema(tags=['Waiting'], request_body=SwaggerWaitingsPostSerializer, manual_parameters=[get_token()])
+    @swagger_auto_schema(tags=['Waiting'], request_body=SwaggerWaitingsPostSerializer,
+                         manual_parameters=[header_authorization()])
     @transaction.atomic
     def post(self, request):
         user = search_user(request)
@@ -80,14 +106,14 @@ class Waitings(APIView):
         serializer = WaitingSerializer(result)
         return Response(serializer.data, status=201)
 
-    @swagger_auto_schema(tags=['Waiting'], manual_parameters=[get_token()])
+    @swagger_auto_schema(tags=['Waiting'], manual_parameters=[header_authorization()])
     @transaction.atomic
     def patch(self, request):
         user = search_user(request)
         phone_num = user.phone_num
         waiting = Waiting.objects.get(phone_num=phone_num, status='WA')
         waiting_id = waiting.waiting_id
-        store_id = waiting.store_id.store_id # waiting 테이블에서 store_id가 외래키 이므로 waiting.store_id=Store(객체)이다.
+        store_id = waiting.store_id.store_id  # waiting 테이블에서 store_id가 외래키 이므로 waiting.store_id=Store(객체)이다.
         try:
             waiting_order = search_waiting_order(waiting_id, store_id)
             Waiting.objects.filter(waiting_id=waiting_id, store_id=store_id).update(status='CN')
@@ -101,7 +127,7 @@ class Waitings(APIView):
                     # 취소한 웨이팅이 1순위였고 다음 웨이팅 팀이 존재할 경우 다음 팀에게 1순위 알림 보내기
                     auto_token = Token.objects.get(waiting_id=waitings[0]).token
                     notify.auto_notify(auto_token)
-                except :
+                except:
                     pass
         except:
             return Response(status=400)


### PR DESCRIPTION
- access토큰 만료시 새로운 access토큰 리턴해주는 기능 추가
- 회원가입/로그인 할때 cache에 { access_token: refresh_token} 저장하는 기능 추가
- 웨이팅 현황 조회에서 웨이팅이 있어도 데이터가 없다고 뜨는 에러 해결
- 대기자 입장에서 response data (가게의 웨이팅 상황, 상세정보, 웨이팅 받는지 여부)추가
- 대기자 호출에서 받는 request를 token에서 waiting_id로 변환